### PR TITLE
Small simplification

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TENxGenomics
 Title: Interface to 10x Genomics data
-Version: 0.0.9
+Version: 0.0.10
 Authors@R:
     person(
         "Martin", "Morgan", email = "Martin.Morgan@RoswellPark.org",


### PR DESCRIPTION
Following bugfix in 201ce39 (woops), no need for `sparse` arg in `.values_and_index()`; efficiency only existed if `cidx` had not already computed