### PR TITLE
resync with some recent changes to HDF5Array

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TENxGenomics
 Title: Interface to 10x Genomics data
-Version: 0.0.25
+Version: 0.0.26
 Authors@R:
     c(person(
         "Martin", "Morgan", email = "Martin.Morgan@RoswellPark.org",
@@ -21,7 +21,7 @@ Description: This package provides an interface to 10xGenomics data,
 Depends: R (>= 3.4.0), methods, Matrix, SummarizedExperiment,
     DelayedArray (>= 0.3.7)
 Imports: rhdf5 (>= 2.19.3-2), tools, BiocGenerics, S4Vectors, IRanges,
-    HDF5Array (>= 1.5.1), BiocParallel (>= 1.11.2)
+    HDF5Array (>= 1.7.6), BiocParallel (>= 1.11.2)
 Suggests: knitr, rmarkdown, BiocFileCache, Rtsne
 Collate:
     TENxGenomics-class.R


### PR DESCRIPTION
Hopefully this will address this error you got a couple of days ago (I don't have an easy way to test this at the moment):
```
> TENxGenomics::TENxMatrix(path)
Error in .check_h5dim(dim, filepath, name) :
  The dimensions (2624828308) of HDF5 dataset 'mm10/data' from file
  '/home/mtmorgan/.ExperimentHub/1039' are too big.

  The HDF5Array package only supports datasets with all dimensions <=
  2^31-1 (= 2147483647) at the moment.
```
